### PR TITLE
Remove regex requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,10 +495,6 @@ A property attribute MUST be one of these:
              <br>Valid for datatypes <code>enum</code>
            </li>
            <li>
-             <code>regex:pattern</code> to provide a regex that can be used to match the value. e.g. <code>regex:[A-Z][0-9]+</code>.
-             <br>Valid for datatype <code>string</code>
-           </li>
-           <li>
              <code>rgb</code> to provide colors in RGB format e.g. <code>255,255,0</code> for yellow.
              <code>hsv</code> to provide colors in HSV format e.g. <code>60,100,100</code> for yellow.
              <br>Valid for datatype <code>color</code>
@@ -506,7 +502,7 @@ A property attribute MUST be one of these:
          </ul>
        </td>
        <td>Yes</td>
-       <td>Depends on $datatype</td>
+       <td>No for $datatype <code>string</code>,<code>integer</code>,<code>float</code>,<code>boolean</code>. Yes for <code>enum</code>,<code>color</code></td>
     </tr>
 </table>
 


### PR DESCRIPTION
* A good regex parser is not lightweight and most likely needs lots of heap memory for the state machine and backreferences and whatnot. Do not make it mandatory to support it.
* Be more precise when the property format attribute is required