### PR TITLE
Use "true" instead of "on"

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ This especially fits well with MQTT, because of retained message.
 For example, a `kitchen-light` device exposing a `light` node would subscribe to `homie/kitchen-light/light/power/set` and it would receive:
 
 ```java
-homie/kitchen-light/light/power/set ← "on"
+homie/kitchen-light/light/power/set ← "true"
 ```
 
 The device would then turn on the light, and update its `power` state.


### PR DESCRIPTION
I guess part of this convention is not only how devices/attributes/nodes/properties present themselves, but also to a certain degree structure and define messages. Be consistent with the example where a boolean value is sent. Use "true" instead of "on".