### PR TITLE
Fixed wording on init state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The `$state` device attribute represents, as the name suggests, the current stat
 There are 6 different states:
 
 * **`init`**: this is the state the device is in when it is connected to the MQTT broker, but has not yet sent all Homie messages and is not yet ready to operate.
-This is the first message that must that must be sent.
+This state is optional, and may be sent if the device takes a long time to initialize, but wishes to announce to consumers that it is coming online. 
 * **`ready`**: this is the state the device is in when it is connected to the MQTT broker, has sent all Homie messages and is ready to operate.
 You have to send this message after all other announcements message have been sent.
 * **`disconnected`**: this is the state the device is in when it is cleanly disconnected from the MQTT broker.


### PR DESCRIPTION
Updated init state wording to indicate the state was optional in the lifecycle and provided an example of when it may be used.

PR based on discussion of #111 
