### PR TITLE
Table cleanup

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -29,6 +29,19 @@ Booleans MUST be converted to "true" or "false".
 The nature of the Homie convention makes it safe about duplicate messages, so the recommended QoS for reliability is **QoS 1**.
 All messages MUST be sent as **retained**, UNLESS stated otherwise.
 
+## Base Topic
+
+The MQTT base topic you will see in the following convention will be `homie/`.
+If this base topic does not suit your needs (in case of, e.g., a public broker), you can choose another.
+
+Be aware, that only the default base topic `homie/` is eligible for automatic discovery by third party controllers.
+
+## Timings
+
+As soon as a device starts to publish any Homie related topic,
+it MUST finish with all topics within a timeframe of 500ms.
+Otherwise a controller can assume that the topic is not set.
+
 ## Topology
 
 **Devices:**
@@ -70,17 +83,6 @@ The precise definition of attributes is important for the automatic discovery of
 
 Examples: A device might have an `IP` attribute, a node will have a `name` attribute, and a property will have a `unit` attribute.
 
-----
-
-### Base Topic
-
-The base topic you will see in the following convention will be `homie/`.
-If this base topic does not suit your needs (in case of, e.g., a public broker), you can choose another.
-
-Be aware, that only the default base topic `homie/` is eligible for automatic discovery by third party controllers.
-
-----
-
 ### Devices
 
 * `homie` / **`device ID`**: this is the base topic of a device.
@@ -89,66 +91,23 @@ Each device must have a unique device ID which adhere to the [ID format](#topic-
 #### Device Attributes
 
 * `homie` / `device ID` / **`$device-attribute`**:
-When the MQTT connection to the broker is established or re-established, the device MUST send its attributes to the broker immediately.
 
-<table>
-  <tr>
-    <th>Topic</th>
-    <th>Direction</th>
-    <th>Description</th>
-    <th>Required</th>
-  </tr>
-  <tr>
-    <td>$homie</td>
-    <td>Device → Controller</td>
-    <td>Version of the Homie convention the device conforms to</td>
-    <td>Yes</td>
-  </tr>
-  <tr>
-    <td>$name</td>
-    <td>Device → Controller</td>
-    <td>Friendly name of the device</td>
-    <td>Yes</td>
-  </tr>
-  <tr>
-    <td>$state</td>
-    <td>Device → Controller</td>
-    <td>
-      See <a href="#device-behavior">Device behavior</a>
-    </td>
-    <td>Yes</td>
-  </tr>
-  <tr>
-    <td>$nodes</td>
-    <td>Device → Controller</td>
-    <td>
-      Nodes the device exposes, with format <code>id</code> separated by a <code>,</code> if there are multiple nodes.
-      To make a node an array, append <code>[]</code> to the ID.
-    </td>
-    <td>Yes</td>
-  </tr>
-  <tr>
-    <td>$extensions</td>
-    <td>Device → Controller</td>
-    <td>
-      List of supported extensions, using `,` as a separator.
-      Must be an empty string, if no extensions are supported.
-    </td>
-    <td>Yes</td>
-  </tr>
-  <tr>
-    <td>$implementation</td>
-    <td>Device → Controller</td>
-    <td>An identifier for the Homie implementation (example <code>esp8266</code>)</td>
-    <td>No</td>
-  </tr>
-  <tr>
-    <td>$stats</td>
-    <td>Device → Controller</td>
-    <td>Specify all optional stats that the device will announce, with format <code>stats</code> separated by a <code>,</code> if there are multiple stats. See next section for an example</td>
-    <td>No</td>
-  </tr>
-</table>
+The following device attributes are mandatory and MUST be send, even if it is just an empty string.
+
+| Topic       |                                                    Description            |
+|-------------|--------------------------------------------------------------------------:|
+| $homie      | The implemented Homie convention version                                  |
+| $name       | Friendly name of the device                                               |
+| $state      | See [Device behavior](#device-behavior)                                   |
+| $nodes      | [Nodes](#nodes) the device exposes, separated by `,` for multiple ones.   |
+| $extensions | Supported extensions, separated by `,` for multiple ones.                 |
+
+Optional topics include:
+
+| Topic           | Description                   |
+|-----------------|-------------------------------|
+| $implementation | An identifier for the Homie implementation (example "esp8266")                     |
+| $stats          | See [Device statistics](#device-statistics), separated by `,` for multiple ones.   |
 
 For example, a device with an ID of `super-car` that comprises off a `wheels`, `engine` and a `lights` node would send:
 
@@ -184,56 +143,16 @@ You have to send this message when something is wrong.
 The `$stats/` hierarchy allows to send device attributes that change over time. All defined topic are optional.
 The interval defined in `$stats/interval` in seconds is a hint to the controller how often the statistics will be updated.
 
-<table>
-  <tr>
-    <th>Topic</th>
-    <th>Direction</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>$stats/interval</td>
-    <td>Device → Controller</td>
-    <td>A hint to the controller how often the statistics will be updated</td>
-  </tr>
-  <tr>
-    <td>$stats/uptime</td>
-    <td>Device → Controller</td>
-    <td>Time elapsed in seconds since the boot of the device</td>
-  </tr>
-  <tr>
-    <td>$stats/signal</td>
-    <td>Device → Controller</td>
-    <td>Signal strength in %</td>
-  </tr>
-  <tr>
-    <td>$stats/cputemp</td>
-    <td>Device → Controller</td>
-    <td>CPU Temperature in °C</td>
-  </tr>
-  <tr>
-    <td>$stats/cpuload</td>
-    <td>Device → Controller</td>
-    <td>
-      CPU Load in %.
-      Average of last <code>$interval</code> including all CPUs
-    </td>
-  </tr>
-  <tr>
-    <td>$stats/battery</td>
-    <td>Device → Controller</td>
-    <td>Battery level in %</td>
-  </tr>
-  <tr>
-    <td>$stats/freeheap</td>
-    <td>Device → Controller</td>
-    <td>Free heap in bytes</td>
-  </tr>
-  <tr>
-    <td>$stats/supply</td>
-    <td>Device → Controller</td>
-    <td>Supply Voltage in V</td>
-  </tr>
-</table>
+| Topic           | Description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| $stats/interval | A hint to the controller how often the statistics will be updated |
+| $stats/uptime   | Time elapsed in seconds since the boot of the device              |
+| $stats/signal   | Signal strength in %                                              |
+| $stats/cputemp  | CPU Temperature in °C                                             |
+| $stats/cpuload  | CPU Load in %. Average of last $interval including all CPUs       |
+| $stats/battery  | Battery level in %                                                |
+| $stats/freeheap | Free heap in bytes                                                |
+| $stats/supply   | Supply Voltage in V                                               |
 
 For example, our `super-car` device with `$stats/interval` value "60" is supposed to send its current values every 60 seconds:
 
@@ -246,8 +165,6 @@ homie/super-car/$stats/signal → "24"
 homie/super-car/$stats/battery → "80"
 ```
 
-----
-
 ### Nodes
 
 * `homie` / `device ID` / **`node ID`**: this is the base topic of a node.
@@ -256,37 +173,14 @@ Each node must have a unique node ID on a per-device basis which adhere to the [
 #### Node Attributes
 
 * `homie` / `device ID` / `node ID` / **`$node-attribute`**:
+
 All listed attributes are **required**. A node attribute MUST be one of these:
 
-<table>
-  <tr>
-    <th>Topic</th>
-    <th>Direction</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>$name</td>
-    <td>Device → Controller</td>
-    <td>Friendly name of the Node</td>
-  </tr>
-  <tr>
-    <td>$type</td>
-    <td>Device → Controller</td>
-    <td>Type of the node</td>
-  </tr>
-  <tr>
-    <td>$properties</td>
-    <td>Device → Controller</td>
-    <td>
-      Properties the node exposes, with format <code>id</code> separated by a <code>,</code> if there are multiple nodes.
-    </td>
-  </tr>
-    <tr>
-       <td>$array</td>
-       <td>Device → Controller</td>
-       <td>Range separated by a <code>-</code>. e.g. <code>0-2</code> for an array with the indexes <code>0</code>, <code>1</code> and <code>2</code></td>
-    </tr>
-</table>
+| Topic       | Description                                                                               |
+|-------------|-------------------------------------------------------------------------------------------|
+| $name       | Friendly name of the Node                                                                 |
+| $type       | Type of the node                                                                          |
+| $properties | Exposed properties, separated by `,` for multiple ones.                                   |
 
 For example, our `engine` node would send:
 
@@ -295,8 +189,6 @@ homie/super-car/engine/$name → "Car engine"
 homie/super-car/engine/$type → "V8"
 homie/super-car/engine/$properties → "speed,direction,temperature"
 ```
-
-----
 
 ### Properties
 
@@ -311,104 +203,22 @@ Each property must have a unique property ID on a per-node basis which adhere to
 #### Property Attributes
 
 * `homie` / `device ID` / `node ID` / `property ID` / **`$property-attribute`**:
-A property attribute MUST be one of these:
 
-<table>
-    <tr>
-        <th>Topic</th>
-        <th>Direction</th>
-        <th>Description</th>
-        <th>Valid values</th>
-        <th>Required (Default)</th>
-    </tr>
-    <tr>
-       <td>$name</td>
-       <td>Device → Controller</td>
-       <td>Friendly name of the property.</td>
-       <td>Any String</td>
-       <td>No ("")</td>
-    </tr>
-    <tr>
-        <td>$settable</td>
-        <td>Device → Controller</td>
-        <td>Specifies whether the property is settable (<code>true</code>) or readonly (<code>false</code>)</td>
-        <td><code>true</code> or <code>false</code></td>
-        <td>No (<code>false</code>)</td>
-    </tr>
-    <tr>
-        <td>$retained</td>
-        <td>Device → Controller</td>
-        <td>Specifies whether the property is retained (<code>true</code>) or non-retained (<code>false</code>). Publishing to a non-retained property topic MUST always happen with the MQTT 'retain' flag off.</td>
-        <td><code>true</code> or <code>false</code></td>
-        <td>No (<code>true</code>)</td>
-    </tr>
-    <tr>
-        <td>$unit</td>
-        <td>Device → Controller</td>
-        <td>
-          A string containing the unit of this property.
-          You are not limited to the recommended values, although they are the only well known ones that will have to be recognized by any Homie consumer.
-        </td>
-        <td>
-            Recommended:<br>
-            <code>°C</code> Degree Celsius<br>
-            <code>°F</code> Degree Fahrenheit<br>
-            <code>°</code> Degree<br>
-            <code>L</code> Liter<br>
-            <code>gal</code> Galon<br>
-            <code>V</code> Volts<br>
-            <code>W</code> Watt<br>
-            <code>A</code> Ampere<br>
-            <code>%</code> Percent<br>
-            <code>m</code> Meter<br>
-            <code>ft</code> Feet<br>
-            <code>Pa</code> Pascal<br>
-            <code>psi</code> PSI<br>
-            <code>#</code> Count or Amount
-        </td>
-        <td>No ("")</td>
-    </tr>
-    <tr>
-       <td>$datatype</td>
-       <td>Device → Controller</td>
-       <td>Describes the format of data.</td>
-       <td>
-         <code>integer</code>,
-         <code>float</code>,
-         <code>boolean</code>,
-         <code>string</code>,
-         <code>enum</code>,
-         <code>color</code>
-       </td>
-       <td>No (<code>string</code>)</td>
-    </tr>
-    <tr>
-       <td>$format</td>
-       <td>Device → Controller</td>
-       <td>
-        Describes what are valid payloads for this property.
-       </td>
-       <td>
-         <ul>
-           <li>
-             <code>from:to</code> Describes a range of payloads e.g. <code>10:15</code>.
-             <br>Valid for datatypes <code>integer</code>, <code>float</code>
-           </li>
-           <li>
-             <code>payload,payload,payload</code> for enumerating all valid payloads.
-             Escape <code>,</code> by using <code>,,</code>. e.g. <code>A,B,C</code> or <code>ON,OFF,PAUSE</code>.
-             <br>Valid for datatypes <code>enum</code>
-           </li>
-           <li>
-             <code>rgb</code> to provide colors in RGB format e.g. <code>255,255,0</code> for yellow.
-             <code>hsv</code> to provide colors in HSV format e.g. <code>60,100,100</code> for yellow.
-             <br>Valid for datatype <code>color</code>
-           </li>
-         </ul>
-       </td>
-       <td>No for $datatype <code>string</code>,<code>integer</code>,<code>float</code>,<code>boolean</code>. Yes for <code>enum</code>,<code>color</code></td>
-    </tr>
-</table>
+The following attributes are required:
+
+| Topic     | Description                                          | Payload type                                |
+|-----------|------------------------------------------------------|---------------------------------------------|
+| $name     | Friendly name of the property.                       | String                                  |
+| $datatype | The data type. See [Payloads](#payloads).            | Enum: \[integer, float, boolean,string, enum, color\] |
+
+The following attributes are optional:
+
+| Topic     | Description                                          |  Payload type                                |
+|-----------|------------------------------------------------------|---------------------------------------------|
+| $format   | Specifies restrictions or options for the given data type | See below                                 |
+| $settable     | Settable (<code>true</code>). Default is read-only (<code>false</code>)  | Boolean     |
+| $retained     | Non-retained (<code>false</code>). Default is Retained (<code>true</code>).  | Boolean     |
+| $unit     | Optional unit of this property. See list below.  | String     |
 
 For example, our `temperature` property would send:
 
@@ -420,6 +230,33 @@ homie/super-car/engine/temperature/$datatype → "float"
 homie/super-car/engine/temperature/$format → "-20:120"
 homie/super-car/engine/temperature → "21.5"
 ```
+
+Format:
+
+* For `integer` and `float`: Describes a range of payloads e.g. `10:15`
+* For `enum`: `payload,payload,payload` for enumerating all valid payloads.
+* For `color`:
+  - `rgb` to provide colors in RGB format e.g. `255,255,0` for yellow.
+  - `hsv` to provide colors in HSV format e.g. `60,100,100` for yellow.
+
+Recommended unit strings:
+
+* `°C`: Degree Celsius
+* `°F`: Degree Fahrenheit
+* `°`: Degree
+* `L`: Liter
+* `gal`: Galon
+* `V`: Volts
+* `W`: Watt
+* `A`: Ampere
+* `%`: Percent
+* `m`: Meter
+* `ft`: Feet
+* `Pa`: Pascal
+* `psi`: PSI
+* `#`: Count or Amount
+
+You are not limited to the recommended values, although they are the only well known ones that will have to be recognized by any Homie consumer.
 
 * `homie` / `device ID` / `node ID` / `property ID` / **`set`**: the device can subscribe to this topic if the property is **settable** from the controller, in case of actuators.
 
@@ -442,8 +279,18 @@ homie/kitchen-light/light/power → "true"
 
 ### Arrays
 
-A node can be an array if you've added `[]` to its ID in the `$nodes` device attribute, and if its `$array` attribute is set to the range of the array.
-Let's consider we want to control independently the front lights and back lights of our `super-car`. Our `lights` node array would look like this. Note that the topic for an element of the array node is the name of the node followed by a `_` and the index getting updated:
+A node can be an array if you've added `[]` to its ID in the `$nodes` device attribute.
+
+You need to specify these additional attributes on the array node:
+
+| Topic       | Description                                                                               |
+|-------------|-------------------------------------------------------------------------------------------|
+| $array      | Range separated by a -. e.g. 0-2 for an array with the indexes 0, 1 and 2                 |
+
+The topic for an element of the array node is the name of the node followed by a `_` and the index.
+
+Example:
+In the following example two lights are grouped in an array:
 
 ```java
 homie/super-car/$nodes → "lights[]"
@@ -465,8 +312,6 @@ homie/super-car/lights_1/intensity → "100"
 ```
 
 Note that you can name each element in your array individually ("Back lights", etc.).
-
-----
 
 ### Broadcast Channel
 


### PR DESCRIPTION
* Move  "Base Topic" to level 2 heading. It is not logically related to the topology
* Add "Timings": Publish procedure must be finished 500ms after the first publish began.
* Split tables into mandatory/optional.
* Remove "direction" column, it's the same for ALL tables so far. If that ever changes, it should be mentioned in the text instead or a separate table is added.
* Convert all tables from HTML to markdown
* Move long descriptions from table cells down into the text
* Add more inter document links for navigation
* Move everything array related to the array section. Clean up array section.