### PR TITLE
Add subheading for "Property command topic"

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -287,6 +287,7 @@ You are not limited to the recommended values, although they are the only well k
 * `homie` / `device ID` / `node ID` / `property ID` / **`set`**: The device must subscribe to this topic if the property is **settable** (in case of actuators for example).
 
 The assigned and processed payload must be reflected by the Homie device in the property topic `homie` / `device ID` / `node ID` / `property ID` as soon as possible.
+This property state update not only informs other devices about the change but closes the control loop for the commanding controller, important for deterministic interaction with the client device.
 
 A Homie controller publishes to the `set` command topic with non-retained messages only.
 

--- a/convention.md
+++ b/convention.md
@@ -297,7 +297,7 @@ To give an example: A `kitchen-light` device exposing the `light` node with a se
 homie/kitchen-light/light/power/set ← "true"
 ```
 
-Following a pessimistic feedback pattern, the device updates its `power` state as soon as turning on the light worked.
+In response the device will turn on the light and upon success update its `power` property state accordingly:
 
 ```java
 homie/kitchen-light/light/power → "true"

--- a/convention.md
+++ b/convention.md
@@ -286,10 +286,10 @@ You are not limited to the recommended values, although they are the only well k
 
 * `homie` / `device ID` / `node ID` / `property ID` / **`set`**: The device must subscribe to this topic if the property is **settable** (in case of actuators for example).
 
+A Homie controller publishes to the `set` command topic with non-retained messages only.
+
 The assigned and processed payload must be reflected by the Homie device in the property topic `homie` / `device ID` / `node ID` / `property ID` as soon as possible.
 This property state update not only informs other devices about the change but closes the control loop for the commanding controller, important for deterministic interaction with the client device.
-
-A Homie controller publishes to the `set` command topic with non-retained messages only.
 
 To give an example: A `kitchen-light` device exposing the `light` node with a settable `power` property subscribes to the topic `homie/kitchen-light/light/power/set` for commands:
 

--- a/convention.md
+++ b/convention.md
@@ -290,15 +290,13 @@ The assigned and processed payload must be reflected by the Homie device in the 
 
 A Homie controller publishes to the command topic with non-retained messages only.
 
-Homie is state-based. You don't tell your smartlight to `turn on`, but you tell it to put its `power` state to `on`.
-
 For example, a `kitchen-light` device exposing a `light` node would subscribe to `homie/kitchen-light/light/power/set` and it would receive:
 
 ```java
 homie/kitchen-light/light/power/set ← "true"
 ```
 
-The device would then turn on the light, and update its `power` state.
+Following a pessimistic feedback pattern, the device updates its `power` state as soon as turning on the light worked.
 
 ```java
 homie/kitchen-light/light/power → "true"

--- a/convention.md
+++ b/convention.md
@@ -290,7 +290,7 @@ The assigned and processed payload must be reflected by the Homie device in the 
 
 A Homie controller publishes to the command topic with non-retained messages only.
 
-For example, a `kitchen-light` device exposing a `light` node would subscribe to `homie/kitchen-light/light/power/set` and it would receive:
+To give an example: A `kitchen-light` device exposing the `light` node with a settable `power` property subscribes to the topic `homie/kitchen-light/light/power/set` for commands:
 
 ```java
 homie/kitchen-light/light/power/set ← "true"

--- a/convention.md
+++ b/convention.md
@@ -288,7 +288,7 @@ You are not limited to the recommended values, although they are the only well k
 
 The assigned and processed payload must be reflected by the Homie device in the property topic `homie` / `device ID` / `node ID` / `property ID` as soon as possible.
 
-A Homie controller publishes to the command topic with non-retained messages only.
+A Homie controller publishes to the `set` command topic with non-retained messages only.
 
 To give an example: A `kitchen-light` device exposing the `light` node with a settable `power` property subscribes to the topic `homie/kitchen-light/light/power/set` for commands:
 

--- a/convention.md
+++ b/convention.md
@@ -282,11 +282,15 @@ Recommended unit strings:
 
 You are not limited to the recommended values, although they are the only well known ones that will have to be recognized by any Homie consumer.
 
-* `homie` / `device ID` / `node ID` / `property ID` / **`set`**: the device can subscribe to this topic if the property is **settable** from the controller, in case of actuators.
+#### Property command topic
 
-Homie is state-based.
-You don't tell your smartlight to `turn on`, but you tell it to put its `power` state to `on`.
-This especially fits well with MQTT, because of retained message.
+* `homie` / `device ID` / `node ID` / `property ID` / **`set`**: The device must subscribe to this topic if the property is **settable** (in case of actuators for example).
+
+The assigned and processed payload must be reflected by the Homie device in the property topic `homie` / `device ID` / `node ID` / `property ID` as soon as possible.
+
+A Homie controller publishes to the command topic with non-retained messages only.
+
+Homie is state-based. You don't tell your smartlight to `turn on`, but you tell it to put its `power` state to `on`.
 
 For example, a `kitchen-light` device exposing a `light` node would subscribe to `homie/kitchen-light/light/power/set` and it would receive:
 
@@ -295,7 +299,6 @@ homie/kitchen-light/light/power/set ← "true"
 ```
 
 The device would then turn on the light, and update its `power` state.
-This provides pessimistic feedback, which is important for home automation.
 
 ```java
 homie/kitchen-light/light/power → "true"


### PR DESCRIPTION
To break up the "Property" section another subheading is introduced.
Some sentences that only justify but do not clarify are removed.
Added the hint that controllers publish to "/set" only with non retained messages.