### PR TITLE
chore(id): simplify ID checks

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -12,7 +12,6 @@ Homie communicates through [MQTT](http://mqtt.org) and is hence based on the bas
 An MQTT topic consists of one or more topic levels, separated by the slash character (`/`).
 A topic level ID MAY ONLY contain lowercase letters from `a` to `z`, numbers from `0` to `9` as well as the hyphen character (`-`).
 
-A topic level ID MUST NOT start or end with a hyphen (`-`).
 The special character `$` is used and reserved for Homie *attributes*.
 
 ### QoS and retained messages


### PR DESCRIPTION
by removing the constraint that an ID cannot start nor end with a '-', the validation becomes a lot simpler. Eg. in Lua which has a pattern matching engine, but not full regex capabilities, the current ID cannot be validated with a single pattern.

A regex would now simply be `^[a-z0-9-]+$` (or `^$*[a-z0-9-]+$` to match homie-keys), also way easier to implement without a regex engine.  Alternatively we could require the ID to be minimum 2 characters in length, which would result in `^[a-z0-9][a-z0-9-]*[a-z0-9]$`, which is still fairly simple.

The current limitation is just for human readability, so even if we remove it, it is most unlikely that one would use that anyway. And as mentioned, it is NOT a technical limitation.