### PR TITLE
clarify(enum): clarify that whitesapce is significant

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -83,7 +83,7 @@ needs this, then it should provide an escape mechanism on the application level.
 
 - Enum payloads must be one of the values specified in the format definition of the property
 - Enum payloads are case sensitive, e.g. "Car" will not match a format definition of "car"
-- Payloads should have leading- and trailing-whitespace removed
+- Leading- and trailing-whitespace is significant, e.g. "Car" will not match " Car".
 - An empty string ("") is not a valid payload
  
 #### Color
@@ -338,7 +338,7 @@ the formats for displaying values.
 |--------------|----------|----------|-------------|
 | float        | no       | `:`      | `[min]:[max][:step]` where min and max are the respective minimum and maximum (inclusive) allowed values, both represented in the format for [float types](#float). Eg. `10.123:15.123`. If the minimum and/or maximum are missing from the format, then they are open-ended, so `0:` allows a value >= 0.<br/>The optional `step` determines the step size, eg. `2:6:2` will allow values `2`, `4`, and `6`. It must be greater than 0. The base for calculating a proper value based on `step` should be `min`, `max`, or the current property value (in that order). The implementation should round property values to the nearest step (which can be outside the min/max range). The min/max validation must be done after rounding. |
 | integer      | no       | `:`      | `[min]:[max][:step]` where min and max are the respective minimum and maximum (inclusive) allowed values, both represented in the format for [integer types](#integer). Eg. `5:35`. If the minimum and/or maximum are missing from the format, then they are open-ended, so `:10` allows a value <= 10. <br/>The optional `step` determines the step size, eg. `2:6:2` will allow values `2`, `4`, and `6`. It must be greater than 0. The base for calculating a proper value based on `step` should be `min`, `max`, or the current property value (in that order). The implementation should round property values to the nearest step (which can be outside the min/max range). The min/max validation must be done after rounding. |
-| enum         | yes      |          | A comma-separated list of non-quoted values. Eg. `value1,value2,value3`. If quotes or whitespace are used adjacent of the '`,`' (comma), then they are part of the value. Individual values can not be an empty string, hence at least 1 value must be specified in the format. |
+| enum         | yes      |          | A comma-separated list of non-quoted values. Eg. `value1,value2,value3`. Leading- and trailing whitespace is significant. Individual values can not be an empty string, hence at least 1 value must be specified in the format. |
 | color        | yes      |          | A comma-separated list of color formats supported; `rgb`, `hsv`, and/or `xyz`. See the [color type](#color) for the resulting value formats. E.g. a device supporting RGB and HSV would have its format set to `"rgb,hsv"`. |
 | boolean      | no       | `false,true` | Identical to an enum with 2 entries. The first represents the `false` value and the second is the `true` value. Eg. `close,open` or `off,on`. If provided, then both entries must be specified. **Important**:  the format does NOT specify valid payloads, they are descriptions of the valid payloads `false` and `true`. |
 


### PR DESCRIPTION
previously it mentioned that whitespace should be removed, but it was not clear whether the sender or receiver was supposed to do this. By making whitespace significant, the whole thing becomes easier to understand and to validate.