### PR TITLE
fix(target): equality of received commands

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -297,33 +297,11 @@ For example, our `engine` node would look like this:
 * `homie` / `5` / `device ID` / `node ID` / **`property ID`**: this is the base topic of a property.
 Each property must have a unique property ID on a per-node basis which adheres to the [ID format](#topic-ids).
 
-* A property payload (e.g. a sensor reading) is directly published to the property topic, e.g.:
-  ```java
-  homie/5/super-car/engine/temperature → "21.5"
-  ```
-  
-* Properties can be **settable**.
-  For example, you don't want your `temperature` property to be settable in case of a temperature sensor
-  (like the car example), but to be settable in the case of a thermostat.
-
-* Properties can be **retained**.
-  A property is retained by default. A non-retained property would be useful for momentary events (doorbell pressed).
-  See also [QoS settings](#qos-and-retained-messages).
-
-A combination of the **settable** and **retained** flags compiles into this list:
-
-| retained | settable | description |
-|----------|----------|-------------|
-| yes      | yes      | The node publishes a property state and can receive commands for the property (by a controller or other party) (lamp power)
-| yes      | no       | (default) The node publishes a property state (temperature sensor)
-| no       | yes      | The node publishes momentary events and can receive commands for the property (by a controller or other party) (brew coffee)
-| no       | no       | The node publishes momentary events (doorbell pressed)
-
-
 #### Property Attributes
 
 | Topic   | Required |   Description            |
 |---------|----------|----------------------------------------------------------------|
+|         | yes      | A property value (e.g. a sensor reading) is directly published to the property topic, e.g.: `homie/5/super-car/engine/temperature → "21.5"` |
 | $target | no       | Describes an intended state change. The `$target` property must either be used for every value update (including the initial one), or it must never be used. |
 
 The Property object itself is described in the `homie` / `5` / `device ID` / `$description` JSON document. The Property object has the following fields:
@@ -354,6 +332,25 @@ And the following MQTT topic with the reported property value:
 ```java
 homie/5/super-car/engine/temperature → "21.5"
 ```
+
+#### Settable and retained properties
+
+Properties can be **settable** and/or **retained**. For example, you don't want your `temperature`
+property to be settable in case of a temperature sensor (like the car example), but it should be
+settable in the case of a thermostat.
+
+A property is retained by default. A non-retained property would be useful for momentary events
+(e.g. doorbell pressed). See also [QoS settings](#qos-and-retained-messages).
+
+A combination of the **settable** and **retained** flags compiles into this list:
+
+| retained | settable | description |
+|----------|----------|-------------|
+| yes      | yes      | The node publishes a property state and can receive commands for the property (by a controller or other party) (lamp power)
+| yes      | no       | (**default**) The node publishes a property state (temperature sensor)
+| no       | yes      | The node publishes momentary events and can receive commands for the property (by a controller or other party) (brew coffee)
+| no       | no       | The node publishes momentary events (doorbell pressed)
+
 
 #### Formats
 

--- a/convention.md
+++ b/convention.md
@@ -423,6 +423,13 @@ optional state-value updates during the transition), and when done update the pr
 
 If a new target is received (and accepted) from a controller by publishing to the property's `set` topic, then the exact value received must be published to the `$target` topic (byte-by-byte equality). To allow for closing the control loop.
 
+**Notes:**
+
+- a controller can only assume that the command it send to the `set` topic was received and accepted. Not necessarily that it will ever reach the target state, since if another controller updates the property again, it might never reach the target state.
+- The same goes for possible conversions (colors), rounding (number formats), etc. it will be very hard to check functional equivalence, since the value published may have a different format. So a controller should NOT implement a retry loop checking the final value. At best they should implement retries until the value set is being accepted.
+- Homie devices representing remote hardware (typically when bridging) should NOT set the `$target` attribute upon receiving a change from the hardware device. This is only allowed if the hardware explicitly distinguishes between current value and target value. This is to prevent a loop; e.g. a homie controller sets 100% as target, software instructs hardware to change, intermediate updates received from hardware; 20%, 40%, etc, should NOT overwrite the `$target` value, since that still is 100.
+
+
 #### Property command topic
 
 * `homie` / `5` / `device ID` / `node ID` / `property ID` / **`set`**: The device must subscribe to this topic if the property is **settable** (in the case of actuators for example).


### PR DESCRIPTION
This PR is mostly reordering of text to align the description of "Property" (which starts with a bullet list for some reason) with the descriptions of "Device" and "Node".

It has 2 commits;
1. implements a change requiring byte-by-byte equality of `$target`
2. finishes the alignment of property/node/device descriptions

The functional change is that if a device implements a `$target` attribute to announce an intended/pending change, it should send a value byte-by-byte equal to the received `set` command. (doesn't apply if the change was initiated from the internal implementation).

This allows a controller to close the control loop and know that the command was successfully received by the device. The byte-by-byte equality makes it easier on the controller side. Since if a device does a color format conversion, a JSON-reencoding, or an int/float rounding, the resulting value might be functionally equivalent, but not byte-by-byte equal, and hence not easily comparable.