### PR TITLE
fix(broadcast): broadcasted messages should be non-retained

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -435,8 +435,9 @@ homie/5/kitchen-light/light/brightness → 100  (after 5 seconds)
 
 Homie defines a broadcast topic, so a controller can broadcast a message to all Homie devices:
 
-* `homie` / `5` / `$broadcast` / **`subtopic`**: `subtopic` can be any topic with single or multiple levels.
-It must adhere to the [ID format](#topic-ids).
+* `homie` / `5` / `$broadcast` / **`subtopic`**: `subtopic` can be any topic with single or multiple levels. It must adhere to the [ID format](#topic-ids).
+
+The messages SHOULD be non-retained.
 
 For example, you might want to broadcast an `alert` event with the alert reason as the payload.
 Devices are then free to react or not.


### PR DESCRIPTION
Messages are all retained unless specified otherwise. This wasn't specified and hence defaults to "retained" which doesn't seem right.

The wording "should" still allows for deviations if needed.