### PR TITLE
Trigger website deployment on convention changes

### DIFF
--- a/.github/workflows/trigger_website.yml
+++ b/.github/workflows/trigger_website.yml
@@ -1,0 +1,17 @@
+name: Trigger Website CI
+
+on:
+  push:
+    branches: [develop]
+    tags: ['**']
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WEBSITE_DISPATCH_PAT }}
+          repository: homieiot/homieiot.github.io
+          event-type: website-deploy


### PR DESCRIPTION
Use a PAT to automatically trigger the website deploy action whenever there are changes to the convention repository.

closes homieiot/homieiot.github.io#15