### PR TITLE
change(version): remove 'higher' constraint

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -188,7 +188,7 @@ The JSON description document is a JSON object with the following fields;
 | Field     | Type         | Required | Default | Nullable | Description |
 |-----------|--------------|----------|---------|----------|-------------|
 | `homie`     |string        | yes      |         | no       | The implemented Homie convention version, without the "patch" level. So the format is `"5.x"`, where the `'x'` is the minor version. |
-| `version`   | integer      | yes      |         | no       | The version of the description document. Whenever the document changes, a new higher version must be assigned. This does not need to be sequential, eg. a timestamp could be used. |
+| `version`   | integer      | yes      |         | no       | The version of the description document. Whenever the document changes, a new version must be assigned. This does not need to be sequential, eg. a timestamp or a random number could be used. |
 | `nodes`     |object        | no       | `{}`    | no       | The [Nodes](#nodes) the device exposes. An object containing the [Nodes](#nodes), indexed by their [ID](#topic-ids). Defaults to an empty object.|
 | `name`      |string        | no       | [device-id] | no       | Friendly name of the device. Defaults to the [ID](#topic-ids) of the device. |
 | `type`      |string        | no       |         | no       | Type of Device. Please ensure proper namespacing to prevent naming collisions. |


### PR DESCRIPTION
This constraint forces the use of persistent storage. By removing it
we can simply start with a random number, e.g. 0-65535 and then increment
it (with possibly a roll-over). Especially for resource constraint
devices (which may not have storage nor be able to do unix timestamps
which is 32 bits).