### PR TITLE
change(definitions): adds top-level 'definitions' section

### DIFF
--- a/convention.md
+++ b/convention.md
@@ -3,6 +3,17 @@
 Version: **<!--VERSION-->x.x.x<!--VERSION-->**
 Date: **<!--DATE-->01. Jan 2000<!--DATE-->**
 
+## Introduction
+
+​The Homie convention is a standardized framework designed to facilitate the
+communication and integration of Internet of Things (IoT) devices using the
+[MQTT protocol](https://mqtt.org).
+
+In particular, the Homie convention defines a consistent topic structure and
+messaging format that enables devices and services to announce themselves and
+their data on an MQTT broker in a uniform manner, supporting automatic device
+discovery.
+
 ## Definitions
 
 - **Device**: an instance of a physical piece of hardware that publishes Nodes and Properties to a MQTT broker. For example, a car, an Arduino/ESP8266 or a coffee machine.

--- a/convention.md
+++ b/convention.md
@@ -10,8 +10,8 @@ communication and integration of Internet of Things (IoT) devices using the
 [MQTT protocol](https://mqtt.org).
 
 In particular, the Homie convention defines a consistent topic structure and
-messaging format that enables devices and services to announce themselves and
-their data on an MQTT broker in a uniform manner, supporting automatic device
+messaging format that enables devices to represent themselves, their data and
+their supported controls/commands in a uniform manner, supporting automatic
 discovery.
 
 ## Definitions

--- a/convention.md
+++ b/convention.md
@@ -147,29 +147,17 @@ A zero length payload published on the `$state` topic indicates a device removal
 
 ## Topology and structure
 
-**Devices:**
-An instance of a physical piece of hardware is called a *device*.
-For example, a car, an Arduino/ESP8266, or a coffee machine.
-Within the convention devices can be modelled to have children. For example, bridge
-devices; a zwave bridge device (the parent) exposes many child devices (the
-zwave devices). There is no depth limit set on additionally nested children.
+The topology of Devices, Nodes and Properties is defined by the following rules:
 
-**Nodes:**
-A *device* can expose multiple *nodes*.
-Nodes are independent or logically separable parts of a device.
-For example, a car might expose a `wheels` node, an `engine` node, and a `lights` node.
+- Within the convention, *devices* can be modelled to have children (**Child Devices**). For example, bridge devices; a zwave bridge device (the parent) exposes many child devices (the zwave devices). There is no depth limit set on additionally nested children.
+- A *device* can expose multiple *nodes*.
+- A *node* can have multiple *properties*.
 
-**Properties:**
-A *node* can have multiple *properties*.
-Properties represent basic characteristics of the node/device, often given as numbers or finite states.
-For example, the `wheels` node might expose an `angle` property.
-The `engine` node might expose a `speed`, `direction`, and `temperature` property.
-The `lights` node might expose an `intensity` and a `color` property.
+### Attributes
 
-**Attributes:**
-*Devices, nodes and properties* have specific *attributes* characterizing them.
-Attributes are represented by a topic identifier starting with `$`.
-The precise definition of attributes is important for the automatic discovery of devices following the Homie convention.
+An **Attribute** is a specific aspect of a *device*, *node* or *property* that is modelled by and directly maps to an MQTT topic. The precise definition of attributes is important for the automatic discovery of devices following the Homie convention.
+
+The convention defines different sets of attributes for *devices*, *nodes* and *properties* respectively. MQTT topic identifiers for topics mapping to attributes always start with `$`.
 
 Examples: A device might have an `IP` attribute, a node will have a `name` attribute, and a property will have a `unit` attribute.
 

--- a/convention.md
+++ b/convention.md
@@ -16,10 +16,15 @@ discovery.
 
 ## Definitions
 
-- **Device**: an instance of a physical piece of hardware that publishes Nodes and Properties to a MQTT broker. For example, a car, an Arduino/ESP8266 or a coffee machine.
-- **Node**: an independent or logically separable part of a device. For example, a car might expose a wheels node, an engine node, and a lights node.
-- **Property**: a basic characteristic of a node. For example, the wheels node might expose an angle property. The engine node might expose a speed, direction, and temperature property. The lights node might expose an intensity and a color property.
-- **Controller**: a software solution that discovers and interacts with Devices through one or more MQTT brokers but does not, by itself, publish MQTT messages.
+- **Device**: a physical appliance or logical entity, such as a car, a coffee
+  machine or a protocol bridge, whose representation is published to an MQTT
+  broker.
+- **Controller**: a software solution that discovers and interacts with
+  *devices* through one or more MQTT brokers.
+
+Note that, for brevity and simplicity, the word &quot;device&quot; is often used
+to denote the combination of an appliance, the computer managing the appliance's
+MQTT representation and the representation itself.
 
 ## MQTT Restrictions
 
@@ -158,17 +163,27 @@ A zero length payload published on the `$state` topic indicates a device removal
 
 ## Topology and structure
 
-The topology of Devices, Nodes and Properties is defined by the following rules:
+**Devices:**
+Within the convention devices can be modelled to have children. For example, bridge
+devices; a zwave bridge device (the parent) exposes many child devices (the
+zwave devices). There is no depth limit set on additionally nested children.
 
-- Within the convention, *devices* can be modelled to have children (**Child Devices**). For example, bridge devices; a zwave bridge device (the parent) exposes many child devices (the zwave devices). There is no depth limit set on additionally nested children.
-- A *device* can expose multiple *nodes*.
-- A *node* can have multiple *properties*.
+**Nodes:**
+A *device* can expose multiple *nodes*.
+Nodes are independent or logically separable parts of a device.
+For example, a car might expose a `wheels` node, an `engine` node, and a `lights` node.
 
-### Attributes
+**Properties:**
+A *node* can have multiple *properties*.
+Properties represent basic characteristics of a node/device, often given as numbers or finite states.
+For example, the `wheels` node might expose an `angle` property.
+The `engine` node might expose a `speed`, `direction`, and `temperature` property.
+The `lights` node might expose an `intensity` and a `color` property.
 
-An **Attribute** is a specific aspect of a *device*, *node* or *property* that is modelled by and directly maps to an MQTT topic. The precise definition of attributes is important for the automatic discovery of devices following the Homie convention.
-
-The convention defines different sets of attributes for *devices*, *nodes* and *properties* respectively. MQTT topic identifiers for topics mapping to attributes always start with `$`.
+**Attributes:**
+*Devices, nodes and properties* have specific *attributes* characterizing them.
+Attributes are represented by a topic identifier starting with `$`.
+The precise definition of attributes is important for the automatic discovery of devices following the Homie convention.
 
 Examples: A device might have an `IP` attribute, a node will have a `name` attribute, and a property will have a `unit` attribute.
 

--- a/convention.md
+++ b/convention.md
@@ -14,13 +14,16 @@ messaging format that enables devices to represent themselves, their data and
 their supported controls/commands in a uniform manner, enabling automatic
 discovery.
 
-## Definitions
+## Roles
 
-- **Device**: a physical appliance or logical entity, such as a car, a coffee
-  machine or a protocol bridge, whose representation is published to an MQTT
-  broker.
-- **Controller**: a software solution that discovers and interacts with
-  *devices* through one or more MQTT brokers.
+When interacting through a shared MQTT broker, implementations of the Homie
+convention can take on one or both of the following roles simultaneously:
+
+- **Device**: an implementation that publishes the representation of a physical
+  appliance or logical entity, such as a car, a coffee machine or a protocol
+  bridge, to an MQTT broker.
+- **Controller**: an implementation that discovers and interacts with *devices*
+  through one or more MQTT brokers.
 
 Note that, for brevity and simplicity, the word &quot;device&quot; is often used
 to denote the combination of an appliance, the computer managing the appliance's

--- a/convention.md
+++ b/convention.md
@@ -7,7 +7,7 @@ Date: **<!--DATE-->01. Jan 2000<!--DATE-->**
 
 - **Device**: an instance of a physical piece of hardware that publishes Nodes and Properties to a MQTT broker. For example, a car, an Arduino/ESP8266 or a coffee machine.
 - **Node**: an independent or logically separable part of a device. For example, a car might expose a wheels node, an engine node, and a lights node.
-- **Property**: a basic characteristics of the node/device. For example, the wheels node might expose an angle property. The engine node might expose a speed, direction, and temperature property. The lights node might expose an intensity and a color property.
+- **Property**: a basic characteristic of the node/device. For example, the wheels node might expose an angle property. The engine node might expose a speed, direction, and temperature property. The lights node might expose an intensity and a color property.
 - **Controller**: a software solution that discovers and interacts with Devices through one or more MQTT brokers but does not, by itself, publish MQTT messages.
 
 ## MQTT Restrictions

--- a/convention.md
+++ b/convention.md
@@ -175,7 +175,7 @@ For example, a car might expose a `wheels` node, an `engine` node, and a `lights
 
 **Properties:**
 A *node* can have multiple *properties*.
-Properties represent basic characteristics of a node/device, often given as numbers or finite states.
+Properties represent basic characteristics of the node, often given as numbers or finite states.
 For example, the `wheels` node might expose an `angle` property.
 The `engine` node might expose a `speed`, `direction`, and `temperature` property.
 The `lights` node might expose an `intensity` and a `color` property.

--- a/convention.md
+++ b/convention.md
@@ -3,9 +3,18 @@
 Version: **<!--VERSION-->x.x.x<!--VERSION-->**
 Date: **<!--DATE-->01. Jan 2000<!--DATE-->**
 
+## Definitions
+
+- **Device**: an instance of a physical piece of hardware that publishes Nodes and Properties to a MQTT broker. For example, a car, an Arduino/ESP8266 or a coffee machine.
+- **Node**: an independent or logically separable part of a device. For example, a car might expose a wheels node, an engine node, and a lights node.
+- **Property**: a basic characteristics of the node/device. For example, the wheels node might expose an angle property. The engine node might expose a speed, direction, and temperature property. The lights node might expose an intensity and a color property.
+- **Controller**: a software solution that discovers and interacts with Devices through one or more MQTT brokers but does not, by itself, publish MQTT messages.
+
 ## MQTT Restrictions
 
 Homie communicates through [MQTT](http://mqtt.org) and is hence based on the basic principles of MQTT topic publication and subscription.
+
+Note that there can be more than one Controller interacting with Devices afferent to the same broker.
 
 ### Topic IDs
 

--- a/convention.md
+++ b/convention.md
@@ -153,7 +153,7 @@ The topology of Devices, Nodes and Properties is defined by the following rules:
 - A *device* can expose multiple *nodes*.
 - A *node* can have multiple *properties*.
 
-### Attributes
+### Attributes
 
 An **Attribute** is a specific aspect of a *device*, *node* or *property* that is modelled by and directly maps to an MQTT topic. The precise definition of attributes is important for the automatic discovery of devices following the Homie convention.
 

--- a/convention.md
+++ b/convention.md
@@ -18,7 +18,7 @@ discovery.
 
 - **Device**: an instance of a physical piece of hardware that publishes Nodes and Properties to a MQTT broker. For example, a car, an Arduino/ESP8266 or a coffee machine.
 - **Node**: an independent or logically separable part of a device. For example, a car might expose a wheels node, an engine node, and a lights node.
-- **Property**: a basic characteristic of the node/device. For example, the wheels node might expose an angle property. The engine node might expose a speed, direction, and temperature property. The lights node might expose an intensity and a color property.
+- **Property**: a basic characteristic of a node. For example, the wheels node might expose an angle property. The engine node might expose a speed, direction, and temperature property. The lights node might expose an intensity and a color property.
 - **Controller**: a software solution that discovers and interacts with Devices through one or more MQTT brokers but does not, by itself, publish MQTT messages.
 
 ## MQTT Restrictions

--- a/convention.md
+++ b/convention.md
@@ -5,7 +5,7 @@ Date: **<!--DATE-->01. Jan 2000<!--DATE-->**
 
 ## Introduction
 
-​The Homie convention is a standardized framework designed to facilitate the
+​The Homie convention is an open standard framework designed to facilitate the
 communication and integration of Internet of Things (IoT) devices using the
 [MQTT protocol](https://mqtt.org).
 

--- a/convention.md
+++ b/convention.md
@@ -23,7 +23,7 @@ convention can take on one or both of the following roles simultaneously:
   appliance or logical entity, such as a car, a coffee machine or a protocol
   bridge, to an MQTT broker.
 - **Controller**: an implementation that discovers and interacts with *devices*
-  through one or more MQTT brokers.
+  over MQTT. For example a mobile app, or an if-this-then-that rules engine.
 
 Note that, for brevity and simplicity, the word &quot;device&quot; is often used
 to denote the combination of an appliance, the computer managing the appliance's

--- a/convention.md
+++ b/convention.md
@@ -30,8 +30,6 @@ MQTT representation and the representation itself.
 
 Homie communicates through [MQTT](http://mqtt.org) and is hence based on the basic principles of MQTT topic publication and subscription.
 
-Note that there can be more than one Controller interacting with Devices afferent to the same broker.
-
 ### Topic IDs
 
 An MQTT topic consists of one or more topic levels, separated by the slash character (`/`).

--- a/convention.md
+++ b/convention.md
@@ -11,7 +11,7 @@ communication and integration of Internet of Things (IoT) devices using the
 
 In particular, the Homie convention defines a consistent topic structure and
 messaging format that enables devices to represent themselves, their data and
-their supported controls/commands in a uniform manner, supporting automatic
+their supported controls/commands in a uniform manner, enabling automatic
 discovery.
 
 ## Definitions


### PR DESCRIPTION
This PR follows up to the discussion in #322 and #323 by adding a top-level section dedicated to definitions at the very top of the spec. The copy itself is taken from both the spec and https://homieiot.github.io/implementations/ .

EDIT 2025-04-07: after speaking with a few other devs interested in Homie, I also added an introductory section for people who might get directed straight to the spec with no prior mentions of what the convention is about.